### PR TITLE
feat(cli): add Docker Compose one-click deployment for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,35 @@ npx openmemory-plus install
 
 安装向导会自动引导你：
 
-1. ✅ 检测系统依赖 (Docker, Ollama, Qdrant, BGE-M3)
-2. ✅ 安装缺失的依赖
+1. ✅ 检测系统依赖 (Docker, Qdrant, Ollama, BGE-M3)
+2. ✅ **Docker Compose 一键部署** (推荐) 或原生安装
 3. ✅ 选择 IDE 类型
 4. ✅ 初始化项目配置
 5. ✅ 显示下一步指引
+
+### 🐳 Docker Compose 一键部署 (推荐)
+
+**只需安装 Docker，其他依赖自动处理！**
+
+```bash
+# 方式 1: 安装时自动检测并使用 Docker Compose
+npx openmemory-plus install
+
+# 方式 2: 显式使用 Docker Compose 模式
+npx openmemory-plus install --compose
+
+# 方式 3: 手动管理依赖服务
+omp deps init      # 初始化配置
+omp deps up        # 启动服务 (Qdrant + Ollama + BGE-M3)
+omp deps status    # 查看状态
+omp deps down      # 停止服务
+```
+
+**优势：**
+- 🎯 只需安装 Docker 一个依赖
+- ⚡ 一键启动所有服务
+- 📦 BGE-M3 模型自动下载
+- 💾 数据持久化，重启不丢失
 
 ### 基本用法
 
@@ -310,8 +334,8 @@ npx openmemory-plus install
 | 依赖 | 版本 | 说明 |
 |------|------|------|
 | Node.js | >= 18.0.0 | 运行 CLI |
-| Docker | 最新版 | 运行 Qdrant 向量数据库 |
-| Ollama | 最新版 | 运行 BGE-M3 嵌入模型 |
+| Docker | 最新版 | **唯一必需依赖** (Docker Compose 模式) |
+| Ollama | 最新版 | 运行 BGE-M3 嵌入模型 (原生模式需要) |
 
 ---
 
@@ -414,6 +438,9 @@ npx openmemory-plus install
 # 交互式安装 (推荐)
 npx openmemory-plus install
 
+# 使用 Docker Compose 一键部署 (推荐)
+npx openmemory-plus install --compose
+
 # 静默安装
 npx openmemory-plus install -y
 
@@ -425,6 +452,33 @@ npx openmemory-plus install --skip-deps
 
 # 显示 MCP 配置
 npx openmemory-plus install --show-mcp
+```
+
+### 🐳 依赖服务管理 (Docker Compose)
+
+```bash
+# 初始化 Docker Compose 配置
+omp deps init
+
+# 启动所有依赖服务 (Qdrant + Ollama + BGE-M3)
+omp deps up
+
+# 启动前拉取最新镜像
+omp deps up --pull
+
+# 停止所有服务
+omp deps down
+
+# 查看服务状态
+omp deps status
+
+# 查看服务日志
+omp deps logs              # 所有服务
+omp deps logs ollama       # 指定服务
+omp deps logs -f           # 持续输出
+
+# 手动下载 BGE-M3 模型
+omp deps pull-model
 ```
 
 ### 诊断命令

--- a/README_EN.md
+++ b/README_EN.md
@@ -269,11 +269,35 @@ npx openmemory-plus install
 
 The install wizard will guide you through:
 
-1. ✅ Detect system dependencies (Docker, Ollama, Qdrant, BGE-M3)
-2. ✅ Install missing dependencies
+1. ✅ Detect system dependencies (Docker, Qdrant, Ollama, BGE-M3)
+2. ✅ **Docker Compose one-click deploy** (recommended) or native install
 3. ✅ Select IDE type
 4. ✅ Initialize project config
 5. ✅ Show next steps
+
+### 🐳 Docker Compose One-Click Deploy (Recommended)
+
+**Just install Docker, everything else is handled automatically!**
+
+```bash
+# Option 1: Auto-detect and use Docker Compose during install
+npx openmemory-plus install
+
+# Option 2: Explicitly use Docker Compose mode
+npx openmemory-plus install --compose
+
+# Option 3: Manually manage dependency services
+omp deps init      # Initialize config
+omp deps up        # Start services (Qdrant + Ollama + BGE-M3)
+omp deps status    # Check status
+omp deps down      # Stop services
+```
+
+**Benefits:**
+- 🎯 Only need to install Docker
+- ⚡ One command starts all services
+- 📦 BGE-M3 model auto-downloads
+- 💾 Data persists across restarts
 
 ### Basic Usage
 
@@ -291,8 +315,8 @@ After installation, use in your AI Agent conversations:
 | Dependency | Version | Purpose |
 |------------|---------|---------|
 | Node.js | >= 18.0.0 | Run CLI |
-| Docker | Latest | Run Qdrant vector database |
-| Ollama | Latest | Run BGE-M3 embedding model |
+| Docker | Latest | **Only required dependency** (Docker Compose mode) |
+| Ollama | Latest | Run BGE-M3 embedding model (native mode only) |
 
 ---
 
@@ -396,6 +420,9 @@ After installation, use in your AI Agent conversations:
 # Interactive install (recommended)
 npx openmemory-plus install
 
+# Use Docker Compose one-click deploy (recommended)
+npx openmemory-plus install --compose
+
 # Silent install
 npx openmemory-plus install -y
 
@@ -407,6 +434,33 @@ npx openmemory-plus install --skip-deps
 
 # Show MCP config
 npx openmemory-plus install --show-mcp
+```
+
+### 🐳 Dependency Service Management (Docker Compose)
+
+```bash
+# Initialize Docker Compose config
+omp deps init
+
+# Start all dependency services (Qdrant + Ollama + BGE-M3)
+omp deps up
+
+# Pull latest images before starting
+omp deps up --pull
+
+# Stop all services
+omp deps down
+
+# Check service status
+omp deps status
+
+# View service logs
+omp deps logs              # All services
+omp deps logs ollama       # Specific service
+omp deps logs -f           # Follow output
+
+# Manually download BGE-M3 model
+omp deps pull-model
 ```
 
 ### Diagnostic Commands

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openmemory-plus",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openmemory-plus",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/cli/src/commands/deps.ts
+++ b/cli/src/commands/deps.ts
@@ -1,0 +1,387 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { existsSync, mkdirSync, copyFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+import { safeExec, waitForService, getPlatform } from '../lib/platform.js';
+import { checkDocker } from '../lib/detector.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface DepsOptions {
+  global?: boolean;
+  pull?: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const COMPOSE_DIR_NAME = '.openmemory-plus';
+const COMPOSE_FILE_NAME = 'docker-compose.yml';
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get the path to the docker-compose.yml file
+ * Default: ~/.openmemory-plus/docker-compose.yml
+ */
+export function getComposeFilePath(useGlobal: boolean = true): string {
+  if (useGlobal) {
+    const globalDir = join(homedir(), COMPOSE_DIR_NAME);
+    return join(globalDir, COMPOSE_FILE_NAME);
+  }
+  return join(process.cwd(), COMPOSE_FILE_NAME);
+}
+
+/**
+ * Get the directory containing the docker-compose.yml
+ */
+export function getComposeDir(useGlobal: boolean = true): string {
+  if (useGlobal) {
+    return join(homedir(), COMPOSE_DIR_NAME);
+  }
+  return process.cwd();
+}
+
+/**
+ * Get the path to the template docker-compose.yml
+ */
+function getTemplateComposePath(): string {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const possiblePaths = [
+    join(__dirname, '..', 'templates', COMPOSE_FILE_NAME),
+    join(__dirname, '..', '..', 'templates', COMPOSE_FILE_NAME),
+    join(__dirname, '..', '..', '..', 'templates', COMPOSE_FILE_NAME),
+  ];
+
+  for (const p of possiblePaths) {
+    if (existsSync(p)) {
+      return p;
+    }
+  }
+
+  throw new Error(
+    `docker-compose.yml 模板未找到。已检查路径:\n${possiblePaths.map((p) => `  - ${p}`).join('\n')}`
+  );
+}
+
+/**
+ * Ensure docker-compose.yml exists, copy from template if not
+ */
+export function ensureComposeFile(useGlobal: boolean = true): string {
+  const composePath = getComposeFilePath(useGlobal);
+  const composeDir = getComposeDir(useGlobal);
+
+  if (!existsSync(composePath)) {
+    // Create directory if needed
+    mkdirSync(composeDir, { recursive: true });
+
+    // Copy template
+    const templatePath = getTemplateComposePath();
+    copyFileSync(templatePath, composePath);
+    console.log(chalk.green(`✓ 创建 ${composePath}`));
+  }
+
+  return composePath;
+}
+
+/**
+ * Check if Docker Compose is available
+ */
+export async function checkDockerCompose(): Promise<boolean> {
+  try {
+    // Try docker compose (v2)
+    const { code } = await safeExec('docker', ['compose', 'version'], { timeout: 5000 });
+    return code === 0;
+  } catch {
+    try {
+      // Try docker-compose (v1)
+      const { code } = await safeExec('docker-compose', ['version'], { timeout: 5000 });
+      return code === 0;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Run docker compose command
+ */
+async function runCompose(args: string[], useGlobal: boolean = true): Promise<{ code: number; stdout: string; stderr: string }> {
+  const composeDir = getComposeDir(useGlobal);
+  const composePath = getComposeFilePath(useGlobal);
+
+  if (!existsSync(composePath)) {
+    throw new Error(`docker-compose.yml 不存在: ${composePath}\n请先运行: omp deps init`);
+  }
+
+  // Try docker compose (v2) first
+  try {
+    return await safeExec('docker', ['compose', '-f', composePath, ...args], {
+      cwd: composeDir,
+      timeout: 300000, // 5 minutes for long operations
+    });
+  } catch {
+    // Fallback to docker-compose (v1)
+    return await safeExec('docker-compose', ['-f', composePath, ...args], {
+      cwd: composeDir,
+      timeout: 300000,
+    });
+  }
+}
+
+// ============================================================================
+// Commands
+// ============================================================================
+
+/**
+ * Initialize docker-compose.yml
+ */
+export async function depsInitCommand(options: DepsOptions): Promise<void> {
+  console.log(chalk.bold.cyan('\n🐳 初始化 Docker Compose 配置\n'));
+
+  // Check Docker
+  const dockerStatus = await checkDocker();
+  if (!dockerStatus.installed) {
+    console.log(chalk.red('❌ Docker 未安装'));
+    console.log(chalk.gray('   请访问 https://docker.com/download 下载安装'));
+    return;
+  }
+
+  if (!dockerStatus.running) {
+    console.log(chalk.yellow('⚠️ Docker 未运行'));
+    console.log(chalk.gray('   请启动 Docker Desktop'));
+    return;
+  }
+
+  // Check Docker Compose
+  const hasCompose = await checkDockerCompose();
+  if (!hasCompose) {
+    console.log(chalk.red('❌ Docker Compose 不可用'));
+    console.log(chalk.gray('   请确保 Docker Desktop 版本 >= 20.10'));
+    return;
+  }
+
+  // Create compose file
+  const useGlobal = options.global !== false;
+  const composePath = ensureComposeFile(useGlobal);
+
+  console.log(chalk.green(`\n✅ Docker Compose 配置已就绪`));
+  console.log(chalk.gray(`   配置文件: ${composePath}`));
+  console.log(chalk.gray('\n   启动服务: omp deps up'));
+}
+
+/**
+ * Start all dependency services
+ */
+export async function depsUpCommand(options: DepsOptions): Promise<void> {
+  console.log(chalk.bold.cyan('\n🚀 启动依赖服务\n'));
+
+  const useGlobal = options.global !== false;
+
+  // Ensure compose file exists
+  try {
+    ensureComposeFile(useGlobal);
+  } catch (e: any) {
+    console.log(chalk.red(`❌ ${e.message}`));
+    return;
+  }
+
+  const spinner = ora('启动 Docker Compose 服务...').start();
+
+  try {
+    // Pull images if requested
+    if (options.pull) {
+      spinner.text = '拉取最新镜像...';
+      await runCompose(['pull'], useGlobal);
+    }
+
+    // Start services
+    spinner.text = '启动服务...';
+    const { code, stderr } = await runCompose(['up', '-d'], useGlobal);
+
+    if (code !== 0) {
+      throw new Error(stderr || '启动失败');
+    }
+
+    spinner.succeed('服务启动中...');
+
+    // Wait for services to be healthy
+    console.log(chalk.gray('\n等待服务就绪...'));
+
+    const qdrantReady = await waitForService('http://localhost:6333/readyz', 30, 1000);
+    console.log(qdrantReady ? chalk.green('  ✓ Qdrant 已就绪') : chalk.yellow('  ⚠ Qdrant 启动中...'));
+
+    const ollamaReady = await waitForService('http://localhost:11434/api/tags', 30, 1000);
+    console.log(ollamaReady ? chalk.green('  ✓ Ollama 已就绪') : chalk.yellow('  ⚠ Ollama 启动中...'));
+
+    // Check BGE-M3 model
+    if (ollamaReady) {
+      console.log(chalk.gray('\n检查 BGE-M3 模型...'));
+      try {
+        const response = await fetch('http://localhost:11434/api/tags');
+        const data = await response.json();
+        const hasModel = data.models?.some((m: any) =>
+          m.name === 'bge-m3' || m.name === 'bge-m3:latest' || m.name.startsWith('bge-m3:')
+        );
+        if (hasModel) {
+          console.log(chalk.green('  ✓ BGE-M3 模型已就绪'));
+        } else {
+          console.log(chalk.yellow('  ⚠ BGE-M3 模型下载中 (首次启动需要几分钟)'));
+          console.log(chalk.gray('    查看进度: omp deps logs bge-m3-init'));
+        }
+      } catch {
+        console.log(chalk.yellow('  ⚠ 无法检查模型状态'));
+      }
+    }
+
+    console.log(chalk.green('\n✅ 依赖服务已启动!'));
+    console.log(chalk.gray('   查看状态: omp deps status'));
+    console.log(chalk.gray('   查看日志: omp deps logs'));
+  } catch (e: any) {
+    spinner.fail('启动失败');
+    console.log(chalk.red(`   ${e.message}`));
+  }
+}
+
+/**
+ * Stop all dependency services
+ */
+export async function depsDownCommand(options: DepsOptions): Promise<void> {
+  console.log(chalk.bold.cyan('\n🛑 停止依赖服务\n'));
+
+  const useGlobal = options.global !== false;
+  const spinner = ora('停止服务...').start();
+
+  try {
+    const { code, stderr } = await runCompose(['down'], useGlobal);
+
+    if (code !== 0) {
+      throw new Error(stderr || '停止失败');
+    }
+
+    spinner.succeed('服务已停止');
+    console.log(chalk.gray('\n   数据已保留在 Docker volumes 中'));
+    console.log(chalk.gray('   重新启动: omp deps up'));
+  } catch (e: any) {
+    spinner.fail('停止失败');
+    console.log(chalk.red(`   ${e.message}`));
+  }
+}
+
+/**
+ * Show status of dependency services
+ */
+export async function depsStatusCommand(options: DepsOptions): Promise<void> {
+  console.log(chalk.bold.cyan('\n📊 依赖服务状态\n'));
+
+  const useGlobal = options.global !== false;
+
+  try {
+    const { code, stdout } = await runCompose(['ps', '--format', 'table'], useGlobal);
+
+    if (code === 0 && stdout.trim()) {
+      console.log(stdout);
+    } else {
+      console.log(chalk.yellow('没有运行中的服务'));
+    }
+
+    // Also check service health
+    console.log(chalk.bold('\n服务健康检查:'));
+
+    try {
+      const qdrantRes = await fetch('http://localhost:6333/readyz');
+      console.log(qdrantRes.ok ? chalk.green('  ✓ Qdrant: 健康') : chalk.yellow('  ⚠ Qdrant: 不健康'));
+    } catch {
+      console.log(chalk.red('  ✗ Qdrant: 未运行'));
+    }
+
+    try {
+      const ollamaRes = await fetch('http://localhost:11434/api/tags');
+      if (ollamaRes.ok) {
+        const data = await ollamaRes.json();
+        const hasModel = data.models?.some((m: any) =>
+          m.name === 'bge-m3' || m.name === 'bge-m3:latest' || m.name.startsWith('bge-m3:')
+        );
+        console.log(chalk.green('  ✓ Ollama: 健康'));
+        console.log(hasModel ? chalk.green('  ✓ BGE-M3: 已安装') : chalk.yellow('  ⚠ BGE-M3: 未安装'));
+      } else {
+        console.log(chalk.yellow('  ⚠ Ollama: 不健康'));
+      }
+    } catch {
+      console.log(chalk.red('  ✗ Ollama: 未运行'));
+    }
+  } catch (e: any) {
+    console.log(chalk.yellow('无法获取服务状态'));
+    console.log(chalk.gray(`   ${e.message}`));
+  }
+}
+
+/**
+ * Show logs of dependency services
+ */
+export async function depsLogsCommand(service: string | undefined, options: DepsOptions & { follow?: boolean }): Promise<void> {
+  const useGlobal = options.global !== false;
+  const args = ['logs'];
+
+  if (options.follow) {
+    args.push('-f');
+  }
+
+  if (service) {
+    args.push(service);
+  }
+
+  try {
+    const { stdout, stderr } = await runCompose(args, useGlobal);
+    if (stdout) console.log(stdout);
+    if (stderr) console.error(stderr);
+  } catch (e: any) {
+    console.log(chalk.red(`无法获取日志: ${e.message}`));
+  }
+}
+
+/**
+ * Pull BGE-M3 model manually
+ */
+export async function depsPullModelCommand(): Promise<void> {
+  console.log(chalk.bold.cyan('\n📥 下载 BGE-M3 模型\n'));
+
+  // Check if Ollama is running
+  try {
+    const response = await fetch('http://localhost:11434/api/tags');
+    if (!response.ok) {
+      throw new Error('Ollama 未响应');
+    }
+  } catch {
+    console.log(chalk.red('❌ Ollama 未运行'));
+    console.log(chalk.gray('   请先启动服务: omp deps up'));
+    return;
+  }
+
+  const spinner = ora('下载 BGE-M3 模型 (约 1.2GB)...').start();
+
+  try {
+    const { code, stderr } = await safeExec('docker', [
+      'exec', 'openmemory-ollama',
+      'ollama', 'pull', 'bge-m3'
+    ], { timeout: 30 * 60 * 1000 }); // 30 minutes
+
+    if (code !== 0) {
+      throw new Error(stderr || '下载失败');
+    }
+
+    spinner.succeed('BGE-M3 模型下载完成');
+  } catch (e: any) {
+    spinner.fail('下载失败');
+    console.log(chalk.red(`   ${e.message}`));
+    console.log(chalk.gray('\n   手动下载: docker exec openmemory-ollama ollama pull bge-m3'));
+  }
+}
+

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,14 @@ import { fileURLToPath } from 'url';
 import { installCommand } from './commands/install.js';
 import { statusCommand } from './commands/status.js';
 import { doctorCommand } from './commands/doctor.js';
+import {
+  depsInitCommand,
+  depsUpCommand,
+  depsDownCommand,
+  depsStatusCommand,
+  depsLogsCommand,
+  depsPullModelCommand,
+} from './commands/deps.js';
 
 // Fix Issue #9: Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -42,6 +50,7 @@ program
   .option('--skip-deps', '跳过依赖安装，仅配置项目')
   .option('--show-mcp', '显示 MCP 配置')
   .option('-f, --force', '强制覆盖已存在的配置文件')
+  .option('--compose', '使用 Docker Compose 一键部署依赖')
   .action(installCommand);
 
 // Secondary commands (for advanced users)
@@ -55,6 +64,48 @@ program
   .description('诊断并修复问题')
   .option('--fix', '自动修复问题')
   .action(doctorCommand);
+
+// Deps command group - Docker Compose based dependency management
+const deps = program
+  .command('deps')
+  .description('🐳 管理依赖服务 (Docker Compose)');
+
+deps
+  .command('init')
+  .description('初始化 Docker Compose 配置')
+  .option('--local', '在当前目录创建配置 (默认: 全局)')
+  .action((options) => depsInitCommand({ global: !options.local }));
+
+deps
+  .command('up')
+  .description('启动所有依赖服务 (Qdrant + Ollama + BGE-M3)')
+  .option('--local', '使用当前目录的配置')
+  .option('--pull', '启动前拉取最新镜像')
+  .action((options) => depsUpCommand({ global: !options.local, pull: options.pull }));
+
+deps
+  .command('down')
+  .description('停止所有依赖服务')
+  .option('--local', '使用当前目录的配置')
+  .action((options) => depsDownCommand({ global: !options.local }));
+
+deps
+  .command('status')
+  .description('查看依赖服务状态')
+  .option('--local', '使用当前目录的配置')
+  .action((options) => depsStatusCommand({ global: !options.local }));
+
+deps
+  .command('logs [service]')
+  .description('查看服务日志 (可选: qdrant, ollama, bge-m3-init)')
+  .option('--local', '使用当前目录的配置')
+  .option('-f, --follow', '持续输出日志')
+  .action((service, options) => depsLogsCommand(service, { global: !options.local, follow: options.follow }));
+
+deps
+  .command('pull-model')
+  .description('手动下载 BGE-M3 模型')
+  .action(depsPullModelCommand);
 
 // Parse and execute
 program.parse();

--- a/cli/templates/docker-compose.yml
+++ b/cli/templates/docker-compose.yml
@@ -1,0 +1,87 @@
+# OpenMemory Plus - Docker Compose Configuration
+# 一键启动所有依赖服务 (Qdrant + Ollama)
+#
+# 使用方法:
+#   启动服务: docker compose up -d
+#   停止服务: docker compose down
+#   查看日志: docker compose logs -f
+#   查看状态: docker compose ps
+#
+# 或使用 CLI:
+#   omp deps up
+#   omp deps down
+#   omp deps status
+
+version: '3.8'
+
+services:
+  # Qdrant 向量数据库
+  # 用于存储用户记忆的向量表示
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: openmemory-qdrant
+    ports:
+      - "6333:6333"   # REST API
+      - "6334:6334"   # gRPC API
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__SERVICE__GRPC_PORT=6334
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # Ollama - 本地 LLM 运行时
+  # 用于运行 BGE-M3 嵌入模型
+  ollama:
+    image: ollama/ollama:latest
+    container_name: openmemory-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # BGE-M3 模型初始化器
+  # 首次启动时自动下载 BGE-M3 模型
+  bge-m3-init:
+    image: ollama/ollama:latest
+    container_name: openmemory-bge-init
+    depends_on:
+      ollama:
+        condition: service_healthy
+    volumes:
+      - ollama_data:/root/.ollama
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "🔄 检查 BGE-M3 模型..."
+        if ollama list | grep -q "bge-m3"; then
+          echo "✅ BGE-M3 模型已存在"
+        else
+          echo "📥 下载 BGE-M3 模型 (约 1.2GB)..."
+          OLLAMA_HOST=http://ollama:11434 ollama pull bge-m3
+          echo "✅ BGE-M3 模型下载完成"
+        fi
+    restart: "no"
+
+volumes:
+  qdrant_data:
+    name: openmemory-qdrant-data
+  ollama_data:
+    name: openmemory-ollama-data
+
+networks:
+  default:
+    name: openmemory-network
+

--- a/cli/tests/deps.test.ts
+++ b/cli/tests/deps.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { getComposeFilePath, getComposeDir, ensureComposeFile, checkDockerCompose } from '../src/commands/deps.js';
+
+// Mock modules
+vi.mock('../src/lib/platform.js', () => ({
+  safeExec: vi.fn(),
+  waitForService: vi.fn(),
+  getPlatform: vi.fn(() => 'darwin'),
+}));
+
+vi.mock('../src/lib/detector.js', () => ({
+  checkDocker: vi.fn(),
+}));
+
+describe('deps', () => {
+  describe('getComposeFilePath', () => {
+    it('should return global path by default', () => {
+      const path = getComposeFilePath();
+      expect(path).toBe(join(homedir(), '.openmemory-plus', 'docker-compose.yml'));
+    });
+
+    it('should return global path when useGlobal is true', () => {
+      const path = getComposeFilePath(true);
+      expect(path).toBe(join(homedir(), '.openmemory-plus', 'docker-compose.yml'));
+    });
+
+    it('should return local path when useGlobal is false', () => {
+      const path = getComposeFilePath(false);
+      expect(path).toBe(join(process.cwd(), 'docker-compose.yml'));
+    });
+  });
+
+  describe('getComposeDir', () => {
+    it('should return global directory by default', () => {
+      const dir = getComposeDir();
+      expect(dir).toBe(join(homedir(), '.openmemory-plus'));
+    });
+
+    it('should return global directory when useGlobal is true', () => {
+      const dir = getComposeDir(true);
+      expect(dir).toBe(join(homedir(), '.openmemory-plus'));
+    });
+
+    it('should return current directory when useGlobal is false', () => {
+      const dir = getComposeDir(false);
+      expect(dir).toBe(process.cwd());
+    });
+  });
+
+  describe('checkDockerCompose', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return true when docker compose v2 is available', async () => {
+      const { safeExec } = await import('../src/lib/platform.js');
+      vi.mocked(safeExec).mockResolvedValueOnce({ code: 0, stdout: 'Docker Compose version v2.x', stderr: '' });
+
+      const result = await checkDockerCompose();
+      expect(result).toBe(true);
+      expect(safeExec).toHaveBeenCalledWith('docker', ['compose', 'version'], { timeout: 5000 });
+    });
+
+    it('should fallback to docker-compose v1 if v2 fails', async () => {
+      const { safeExec } = await import('../src/lib/platform.js');
+      vi.mocked(safeExec)
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ code: 0, stdout: 'docker-compose version 1.x', stderr: '' });
+
+      const result = await checkDockerCompose();
+      expect(result).toBe(true);
+      expect(safeExec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return false when neither docker compose is available', async () => {
+      const { safeExec } = await import('../src/lib/platform.js');
+      vi.mocked(safeExec)
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockRejectedValueOnce(new Error('not found'));
+
+      const result = await checkDockerCompose();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('ensureComposeFile', () => {
+    const testDir = join(tmpdir(), 'omp-test-deps');
+    const originalCwd = process.cwd();
+
+    beforeEach(() => {
+      // Clean up test directory
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true });
+      }
+      mkdirSync(testDir, { recursive: true });
+      process.chdir(testDir);
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true });
+      }
+    });
+
+    it('should create docker-compose.yml in local directory when useGlobal is false', () => {
+      // Suppress console.log output
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const composePath = ensureComposeFile(false);
+
+      expect(existsSync(composePath)).toBe(true);
+      // Use endsWith to handle macOS /private/var vs /var symlink issue
+      expect(composePath.endsWith('docker-compose.yml')).toBe(true);
+      expect(composePath).toContain('omp-test-deps');
+
+      // Verify content is valid YAML with expected services
+      const content = readFileSync(composePath, 'utf-8');
+      expect(content).toContain('qdrant');
+      expect(content).toContain('ollama');
+      expect(content).toContain('bge-m3-init');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not overwrite existing docker-compose.yml', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // Create first time
+      const composePath1 = ensureComposeFile(false);
+      const content1 = readFileSync(composePath1, 'utf-8');
+
+      // Create second time - should not change
+      const composePath2 = ensureComposeFile(false);
+      const content2 = readFileSync(composePath2, 'utf-8');
+
+      expect(composePath1).toBe(composePath2);
+      expect(content1).toBe(content2);
+
+      consoleSpy.mockRestore();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary

This PR simplifies dependency installation by adding Docker Compose one-click deployment support.

## Changes

### New Files
- `cli/src/commands/deps.ts` - New deps command module
- `cli/templates/docker-compose.yml` - Docker Compose config template
- `cli/tests/deps.test.ts` - Unit tests (11 new tests)

### Modified Files
- `cli/src/index.ts` - Register deps command group
- `cli/src/commands/install.ts` - Add --compose option
- `README.md` - Add Docker Compose documentation (Chinese)
- `README_EN.md` - Add Docker Compose documentation (English)

## New Commands

```bash
# Dependency service management
omp deps init        # Initialize Docker Compose config
omp deps up          # Start all services (Qdrant + Ollama + BGE-M3)
omp deps down        # Stop all services
omp deps status      # Check service status
omp deps logs        # View logs
omp deps pull-model  # Manually download BGE-M3 model

# Install with Docker Compose
npx openmemory-plus install --compose
```

## Benefits

| Before | After |
|--------|-------|
| Install Docker manually | Install Docker (one-time) |
| Install Ollama manually | ✅ Auto-handled |
| Start Ollama manually | ✅ Auto-handled |
| Download BGE-M3 (~1.2GB) manually | ✅ Auto-downloads |
| Start Qdrant container manually | ✅ Auto-handled |

**User only needs Docker installed, everything else is automatic!**

## Test Results

```
Test Files  8 passed (8)
Tests       75 passed (75)
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author